### PR TITLE
Added `kind` parameter to fetch other fund types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tefas = Crawler()
 
 ## API
 
-### `fetch(start, end, name, columns)`
+### `fetch(start, end, name, columns, kind)`
 
 |Argument|Type|Description|Required|
 |--|--|--|--|
@@ -34,6 +34,7 @@ tefas = Crawler()
 |**end**|`string` or `datetime.datetime`|End of the period that fund information is crawled for.|No|
 |**name**|`string`|Name of the fund. If not given, all funds will be returned.|No|
 |**columns[]**|`list` of `string`|List of columns to be returned.|No|
+|**kind**|`string`|Type of the fund. One of `YAT`, `EMK`, or `BYF`. Defaults to `YAT`.|No|
 
 ### Examples
 

--- a/tefas/crawler.py
+++ b/tefas/crawler.py
@@ -65,6 +65,7 @@ class Crawler:
         end: Optional[Union[str, datetime]] = None,
         name: Optional[str] = None,
         columns: Optional[List[str]] = None,
+        kind: Optional[str] = "YAT",
     ) -> pd.DataFrame:
         """Main entry point of the public API. Get fund information.
 
@@ -73,17 +74,26 @@ class Crawler:
             end: End of the period that fund information is crawled for. (optional)
             name: Name of the fund. If not given, all funds will be returned. (optional)
             columns: List of columns to be returned. (optional)
+            kind: Type of the fund. One of `YAT`, `EMK`, or `BYF`. Defaults to `YAT`. (optional)
+                - `YAT`: Securities Mutual Funds
+                - `EMK`: Pension Funds
+                - `BYF`: Exchange Traded Funds
 
         Returns:
             A pandas DataFrame where each row is the information for a fund.
 
         Raises:
             ValueError if date format is wrong.
-        """
+        """  # noqa
+        assert kind in [
+            "YAT",
+            "EMK",
+            "BYF",
+        ], "`kind` should be one of `YAT`, `EMK`, or `BYF`"
         start_date = _parse_date(start)
         end_date = _parse_date(end or start)
         data = {
-            "fontip": "YAT",
+            "fontip": kind,
             "bastarih": start_date,
             "bittarih": end_date,
             "fonkod": name.upper() if name else "",
@@ -128,7 +138,7 @@ def _parse_date(date: Union[str, datetime]) -> str:
             parsed = datetime.strptime(date, "%Y-%m-%d")
         except ValueError as exc:
             raise ValueError(
-                "Date string format is incorrect. " "It should be `YYYY-MM-DD`"
+                "Date string format is incorrect. It should be `YYYY-MM-DD`"
             ) from exc
         else:
             formatted = datetime.strftime(parsed, "%d.%m.%Y")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -7,6 +7,7 @@ def test_crawler():
     crawler = Crawler()
     assert crawler
 
+
 def test_empty_result():
     """Test the client when POST to tefas returns empty list"""
     Crawler._do_post = MagicMock(return_value=[])


### PR DESCRIPTION
YAT, EMK, and BYF are valid fund types. The word `kind`is choosed deliberately since `type` is a reserved word.

Fixes https://github.com/burakyilmaz321/tefas-crawler/issues/17