### PR TITLE
Detail schema missing properties, error handling and retry mechanism for post request

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,41 +54,64 @@ data = tefas.fetch(start="2020-11-15", end="2020-11-20", name="YAC", columns=["c
 
 As of today, we support the following data schema from [Tefas](http://www.fundturkey.com.tr):
 
-| Column | Description | Type |
-|---|---|---|
-| date | Sate | `date` |
-| price | Price of the fund for a given date | `string` |
-| code | Short code of the fund | `string` |
-| title | Full name of the fund | `string` |
-| market_cap | Total value of the fund | `float` |
-| number_of_shares | Number of outstanding shares | `float` |
-| number_of_investors | Number of participants | `float` |
-| tmm | Share of tmm | `float` |
-| repo | Share of repo | `float` |
-| other | Share of other | `float` |
-| stock | Share of stock | `float` |
-| eurobonds | Share of eurobonds | `float` |
-| bank_bills | Share of bank bills | `float` |
-| derivatives | Share of derivatives | `float` |
-| reverse_repo | Share of reverse-repo | `float` |
-| term_deposit | Share of term deposit | `float` |
-| treasury_bill | Share of treasury bill | `float` |
-| foreign_equity | Share of foreign equity | `float` |
-| government_bond | Share of government bond | `float` |
-| precious_metals | Share of precious metals | `float` |
-| commercial_paper | Share of commercial paper | `float` |
-| fx_payable_bills | Share of fx payable bills | `float` |
-| foreign_securities | Share of foreign securities | `float` |
-| private_sector_bond | Share of private sector bond | `float` |
-| participation_account | Share of participation account | `float` |
-| foreign_currency_bills | Share of foreign currency bills | `float` |
-| asset_backed_securities | Share of asset-backed securities | `float` |
-| real_estate_certificate | Share of real estate certificate | `float` |
-| foreign_debt_instruments | Share of foreign debt instruments | `float` |
-| government_lease_certificates | Share of government lease certificates | `float` |
-| fund_participation_certificate | Share of fund participation certificate | `float` |
-| government_bonds_and_bills_fx | Share of government bonds and bills (fx) | `float` |
-| private_sector_lease_certificates | Share of private sector lease certificates | `float` |
+| Column                                         | Description                                                | Type |
+|------------------------------------------------|------------------------------------------------------------|---|
+| date                                           | Sate                                                       | `date` |
+| price                                          | Price of the fund for a given date                         | `string` |
+| code                                           | Short code of the fund                                     | `string` |
+| title                                          | Full name of the fund                                      | `string` |
+| market_cap                                     | Total value of the fund                                    | `float` |
+| number_of_shares                               | Number of outstanding shares                               | `float` |
+| number_of_investors                            | Number of participants                                     | `float` |
+| bank_bills                                     | Share of bank bills                                        | `float` |
+| exchange_traded_fund                           | Share of exchange traded fund                              | `float` |
+| other                                          | Share of other                                             | `float` |
+| fx_payable_bills                               | Share of fx payable bills                                  | `float` |
+| government_bond                                | Share of government bond                                   | `float` |
+| foreign_currency_bills                         | Share of foreign currency bills                            | `float` |
+| eurobonds                                      | Share of eurobonds                                         | `float` |
+| commercial_paper                               | Share of commercial paper                                  | `float` |
+| fund_participation_certificate                 | Share of fund participation certificate                    | `float` |
+| real_estate_certificate                        | Share of real estate certificate                           | `float` |
+| venture_capital_investment_fund_participation  | Share of venture capital investment fund                   | `float` |
+| real_estate_investment_fund_participation      | Share of real estate investment fund                       | `float` |
+| treasury_bill                                  | Share of treasury bill                                     | `float` |
+| stock                                          | Share of stock                                             | `float` |
+| government_bonds_and_bills_fx                  | Share of government bonds and bills (fx)                   | `float` |
+| participation_account                          | Share of participation account                             | `float` |
+| participation_account_au                       | Share of gold participation account                        | `float` |
+| participation_account_d                        | Share of foreign currency participation account            | `float` |
+| participation_account_tl                       | Share of Turkish Lira participation account                | `float` |
+| government_lease_certificates                  | Share of government lease certificates                     | `float` |
+| government_lease_certificates_d                | Share of foreign currency government lease certificates    | `float` |
+| government_lease_certificates_tl               | Share of Turkish Lira government lease certificates        | `float` |
+| government_lease_certificates_foreign          | Share of government foreign lease certificates             | `float` |
+| precious_metals                                | Share of precious metals                                   | `float` |
+| precious_metals_byf                            | Share of precious metals stock market investment fund      | `float` |
+| precious_metals_kba                            | Share of precious metals government dept instrument        | `float` |
+| precious_metals_kks                            | Share of precious metals public lease certificates         | `float` |
+| public_domestic_debt_instruments               | Share of foreign exchange public domestic debt instruments | `float` |
+| private_sector_lease_certificates              | Share of private sector lease certificates                 | `float` |
+| private_sector_bond                            | Share of private sector bond                               | `float` |
+| repo                                           | Share of repo                                              | `float` |
+| derivatives                                    | Share of derivatives                                       | `float` |
+| tmm                                            | Share of tmm                                               | `float` |
+| reverse_repo                                   | Share of reverse-repo                                      | `float` |
+| asset_backed_securities                        | Share of asset-backed securities                           | `float` |
+| term_deposit                                   | Share of term deposit                                      | `float` |
+| term_deposit_au                                | Share of gold term deposit                                 | `float` |
+| term_deposit_d                                 | Share of foreign currency term deposit                     | `float` |
+| term_deposit_tl                                | Share of Turkish Lira term deposit                         | `float` |
+| futures_cash_collateral                        | Share of futures cash collateral                           | `float` |
+| foreign_debt_instruments                       | Share of foreign debt instruments                          | `float` |
+| foreign_domestic_debt_instruments              | Share of foreign domestic debt instruments                 | `float` |
+| foreign_private_sector_debt_instruments        | Share of foreign private sector debt instruments           | `float` |
+| foreign_exchange_traded_funds                  | Share of foreign exchange traded funds                     | `float` |
+| foreign_equity                                 | Share of foreign equity                                    | `float` |
+| foreign_securities                             | Share of foreign securities                                | `float` |
+| foreign_investment_fund_participation_shares   | Share of foreign investment fund participation             | `float` |
+| private_sector_international_lease_certificate | Share of private sector international lease certificate    | `float` |
+| private_sector_foreign_debt_instruments        | Share of private sector foreign dept instruments           | `float` |
 
 ## To-do
 

--- a/tefas/crawler.py
+++ b/tefas/crawler.py
@@ -11,6 +11,7 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
+import time
 
 from tefas.schema import BreakdownSchema, InfoSchema
 
@@ -119,16 +120,25 @@ class Crawler:
 
         return merged
 
-    def _do_post(self, endpoint: str, data: Dict[str, str]) -> Dict[str, str]:
-        # TODO: error handling. this is quiet fishy now.
-        response = self.session.post(
-            url=f"{self.root_url}/{endpoint}",
-            data=data,
-            cookies=self.cookies,
-            headers=self.headers,
-        )
-        return response.json().get("data", {})
-
+    def _do_post(self, endpoint: str, data: Dict[str, str], attempt: int = 0) -> Dict[str, str]:
+        max_attempt = 5
+        try:
+            response = self.session.post(
+                url=f"{self.root_url}/{endpoint}",
+                data=data,
+                cookies=self.cookies,
+                headers=self.headers,
+            )
+            return response.json().get("data", {})
+        except ValueError:
+            if attempt == max_attempt:
+                raise Exception("Max attempt limit reached. Wait for a while before trying again")
+            attempt += 1
+            sleep_sec = attempt * 5
+            print("Stuck at rate limiting or robot check. Waiting for "+str(sleep_sec)+" seconds to retry. Attempt #"+str(attempt))
+            time.sleep(sleep_sec)
+            print("Trying..")
+            return self._do_post(endpoint, data, attempt)
 
 def _parse_date(date: Union[str, datetime]) -> str:
     if isinstance(date, datetime):

--- a/tefas/schema.py
+++ b/tefas/schema.py
@@ -85,7 +85,7 @@ class BreakdownSchema(Schema):
     foreign_exchange_traded_funds = fields.Float(data_key="YBYF", allow_none=True)  # Yabancı Borsa Yatırım Fonları
     foreign_equity = fields.Float(data_key="YHS", allow_none=True)  # Yabancı Hisse Senedi
     foreign_securities = fields.Float(data_key="YMK", allow_none=True)  # Yabancı Menkul Kıymet
-    foreign_exchange_traded_funds_temp = fields.Float(data_key="YYF", allow_none=True) # Yatırım fonları katılma payları
+    foreign_investment_fund_participation_shares = fields.Float(data_key="YYF", allow_none=True) # Yatırım fonları katılma payları
     private_sector_international_lease_certificate = fields.Float(data_key="ÖKSYD", allow_none=True)  # Özel Sektör Yurt Dışı Kira Sertifikaları
     private_sector_foreign_debt_instruments = fields.Float(data_key="ÖSDB", allow_none=True)  # Özel Sektör Dış Borçlanma Araçları
 

--- a/tefas/schema.py
+++ b/tefas/schema.py
@@ -37,34 +37,57 @@ class InfoSchema(Schema):
 
 
 class BreakdownSchema(Schema):
-    date = fields.Date(data_key="TARIH", allow_none=True)
-    tmm = fields.Float(data_key="TMM (%)", allow_none=True)
-    repo = fields.Float(data_key="R", allow_none=True)
     code = fields.String(data_key="FONKODU", allow_none=True)
-    other = fields.Float(data_key="D", allow_none=True)
-    stock = fields.Float(data_key="HS", allow_none=True)
-    eurobonds = fields.Float(data_key="EUT", allow_none=True)
-    bank_bills = fields.Float(data_key="BB", allow_none=True)
-    derivatives = fields.Float(data_key="T", allow_none=True)
-    reverse_repo = fields.Float(data_key="TR", allow_none=True)
-    term_deposit = fields.Float(data_key="VM", allow_none=True)
-    treasury_bill = fields.Float(data_key="HB", allow_none=True)
-    foreign_equity = fields.Float(data_key="YHS", allow_none=True)
-    government_bond = fields.Float(data_key="DT", allow_none=True)
-    precious_metals = fields.Float(data_key="KM", allow_none=True)
-    commercial_paper = fields.Float(data_key="FB", allow_none=True)
-    fx_payable_bills = fields.Float(data_key="DB", allow_none=True)
-    foreign_securities = fields.Float(data_key="YMK", allow_none=True)
-    private_sector_bond = fields.Float(data_key="OST", allow_none=True)
-    participation_account = fields.Float(data_key="KH", allow_none=True)
-    foreign_currency_bills = fields.Float(data_key="DÖT", allow_none=True)
-    asset_backed_securities = fields.Float(data_key="VDM", allow_none=True)
-    real_estate_certificate = fields.Float(data_key="GAS", allow_none=True)
-    foreign_debt_instruments = fields.Float(data_key="YBA", allow_none=True)
-    government_lease_certificates = fields.Float(data_key="KKS", allow_none=True)
-    fund_participation_certificate = fields.Float(data_key="FKB", allow_none=True)
-    government_bonds_and_bills_fx = fields.Float(data_key="KBA", allow_none=True)
-    private_sector_lease_certificates = fields.Float(data_key="OSKS", allow_none=True)
+    date = fields.Date(data_key="TARIH", allow_none=True)
+    bank_bills = fields.Float(data_key="BB", allow_none=True)  # Banka Bonosu
+    exchange_traded_fund = fields.Float(data_key="BYF", allow_none=True)  # BYF Katılma Payları
+    other = fields.Float(data_key="D", allow_none=True)  # Diğer
+    fx_payable_bills = fields.Float(data_key="DB", allow_none=True)  # Döviz Ödemeli Bono
+    government_bond = fields.Float(data_key="DT", allow_none=True)  # Devlet Tahvili
+    foreign_currency_bills = fields.Float(data_key="DÖT", allow_none=True)  # Dövize Ödemeli Tahvil
+    eurobonds = fields.Float(data_key="EUT", allow_none=True)  # Eurobonds
+    commercial_paper = fields.Float(data_key="FB", allow_none=True)  # Finansman Bonosu
+    fund_participation_certificate = fields.Float(data_key="FKB", allow_none=True)  # Fon Katılma Belgesi
+    real_estate_certificate = fields.Float(data_key="GAS", allow_none=True)  # Gayrimenkul Sertifikası
+    venture_capital_investment_fund_participation = fields.Float(data_key="GSYKB", allow_none=True)  # Girişim Sermayesi Yatırım Fon Katılma Payları
+    real_estate_investment_fund_participation = fields.Float(data_key="GYKB", allow_none=True)  # Gayrimenkul Yatırım Fon Katılma Payları
+    treasury_bill = fields.Float(data_key="HB", allow_none=True)  # Hazine Bonosu
+    stock = fields.Float(data_key="HS", allow_none=True)  # Hisse Senedi
+    government_bonds_and_bills_fx = fields.Float(data_key="KBA", allow_none=True)  # Kamu Dış Borçlanma Araçları
+    participation_account = fields.Float(data_key="KH", allow_none=True)  # Katılma Hesabı
+    participation_account_au = fields.Float(data_key="KHAU", allow_none=True)  # Katılma Hesabı Altın
+    participation_account_d = fields.Float(data_key="KHD", allow_none=True)  # Katılma Hesabı Döviz
+    participation_account_tl = fields.Float(data_key="KHTL", allow_none=True)  # Katılma Hesabı Türk Lirası
+    government_lease_certificates = fields.Float(data_key="KKS", allow_none=True)  # Kamu Kira Sertifikaları
+    government_lease_certificates_d = fields.Float(data_key="KKSD", allow_none=True)  # Kamu Kira Sertifikaları Döviz
+    government_lease_certificates_tl = fields.Float(data_key="KKSTL", allow_none=True)  # Kamu Kira Sertifikaları Türk Lirası
+    government_lease_certificates_foreign = fields.Float(data_key="KKSYD", allow_none=True)  # Kamu Yurt Dışı Kira Sertifikaları
+    precious_metals = fields.Float(data_key="KM", allow_none=True)  # Kıymetli Madenler
+    precious_metals_byf = fields.Float(data_key="KMBYF", allow_none=True)  # Kıymetli Madenler Cinsinden BYF
+    precious_metals_kba = fields.Float(data_key="KMKBA", allow_none=True)  # Kıymetli Madenler Kamu B. A.
+    precious_metals_kks = fields.Float(data_key="KMKKS", allow_none=True)  # Kıymetli Madenler Kamu Kira Sertifikaları
+    public_domestic_debt_instruments = fields.Float(data_key="KİBD", allow_none=True)  # Döviz Kamu İç Borçlanma Araçları
+    private_sector_lease_certificates = fields.Float(data_key="OSKS", allow_none=True)  # Özel Sektör Kira Sertifikaları
+    private_sector_bond = fields.Float(data_key="OST", allow_none=True)  # Özel Sektör Tahvili
+    repo = fields.Float(data_key="R", allow_none=True)  # Repo
+    derivatives = fields.Float(data_key="T", allow_none=True)  # Türev Araçları
+    tmm = fields.Float(data_key="TPP", allow_none=True)  # Takasbank Para Piyasası
+    reverse_repo = fields.Float(data_key="TR", allow_none=True)  # Ters Repo
+    asset_backed_securities = fields.Float(data_key="VDM", allow_none=True)  # Varlığa Dayalı Menkul Kıymetler
+    term_deposit = fields.Float(data_key="VM", allow_none=True)  # Vadeli Mevduat
+    term_deposit_au = fields.Float(data_key="VMAU", allow_none=True)  # Vadeli Mevduat Altın
+    term_deposit_d = fields.Float(data_key="VMD", allow_none=True)  # Vadeli Mevduat Döviz
+    term_deposit_tl = fields.Float(data_key="VMTL", allow_none=True)  # Vadeli Mevduat Türk Lirası
+    futures_cash_collateral = fields.Float(data_key="VİNT", allow_none=True)  # Vadeli İşlemler Nakit Teminatları
+    foreign_debt_instruments = fields.Float(data_key="YBA", allow_none=True)  # Yabancı Borçlanma Aracı
+    foreign_domestic_debt_instruments = fields.Float(data_key="YBKB", allow_none=True)  # Yabancı Kamu Borçlanma Araçları
+    foreign_private_sector_debt_instruments = fields.Float(data_key="YBOSB", allow_none=True)  # Yabancı Özel Sektör Borçlanma Araçları
+    foreign_exchange_traded_funds = fields.Float(data_key="YBYF", allow_none=True)  # Yabancı Borsa Yatırım Fonları
+    foreign_equity = fields.Float(data_key="YHS", allow_none=True)  # Yabancı Hisse Senedi
+    foreign_securities = fields.Float(data_key="YMK", allow_none=True)  # Yabancı Menkul Kıymet
+    foreign_exchange_traded_funds_temp = fields.Float(data_key="YYF", allow_none=True) # Yatırım fonları katılma payları
+    private_sector_international_lease_certificate = fields.Float(data_key="ÖKSYD", allow_none=True)  # Özel Sektör Yurt Dışı Kira Sertifikaları
+    private_sector_foreign_debt_instruments = fields.Float(data_key="ÖSDB", allow_none=True)  # Özel Sektör Dış Borçlanma Araçları
 
     # pylint: disable=no-self-use
     # pylint: disable=unused-argument


### PR DESCRIPTION
Added missing columns for detail schema and fixed one wrong column  (TMM (%) should be TPP)
Reordered detail schema by response order for better compare experience
Matched Tefas table Turkish column names with schema properties for better compare experience
Couldn't catch the reason (could be too frequent request but not 100% sure) but sometimes server responds something similar like captcha check in HTML instead of JSON response. So added an error handling and retry mechanism if post request fails for some reason.