### PR TITLE
Modernize HTTP client and improve date parsing flexibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,11 @@ classifier =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    requests
+    httpx>=0.27.0
     marshmallow
     pandas
-    urllib3
+    tenacity>=8.0.0
+    python-dateutil>=2.8.0
 
 [options.extras_require]
 dev =

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,15 +1,174 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, Mock
+from datetime import datetime, date
+
+import pytest
+import httpx
 
 from tefas import Crawler
+from tefas.crawler import _parse_date, _get_client
 
 
-def test_crawler():
-    crawler = Crawler()
-    assert crawler
+class TestParseDateFunction:
+    """Test the flexible date parsing functionality"""
+
+    def test_parse_iso_format(self):
+        """Test ISO format YYYY-MM-DD"""
+        result = _parse_date("2020-11-20")
+        assert result == "20.11.2020"
+
+    def test_parse_european_format(self):
+        """Test European format DD.MM.YYYY"""
+        result = _parse_date("20.11.2020")
+        assert result == "20.11.2020"
+
+    def test_parse_slash_format(self):
+        """Test slash format DD/MM/YYYY (with dayfirst=True)"""
+        result = _parse_date("20/11/2020")
+        assert result == "20.11.2020"
+
+    def test_parse_human_readable(self):
+        """Test human readable format"""
+        result = _parse_date("Nov 20, 2020")
+        assert result == "20.11.2020"
+
+    def test_parse_long_month_format(self):
+        """Test long month format"""
+        result = _parse_date("20 November 2020")
+        assert result == "20.11.2020"
+
+    def test_parse_datetime_object(self):
+        """Test datetime object input"""
+        dt = datetime(2020, 11, 20, 10, 30, 0)
+        result = _parse_date(dt)
+        assert result == "20.11.2020"
+
+    def test_parse_date_object(self):
+        """Test date object input"""
+        d = date(2020, 11, 20)
+        result = _parse_date(d)
+        assert result == "20.11.2020"
+
+    def test_parse_invalid_string(self):
+        """Test invalid date string raises ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            _parse_date("not-a-date")
+        assert "Could not parse date string" in str(exc_info.value)
+
+    def test_parse_invalid_type(self):
+        """Test invalid type raises ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            _parse_date(12345)
+        assert "should be a string" in str(exc_info.value)
 
 
-def test_empty_result():
-    """Test the client when POST to tefas returns empty list"""
-    Crawler._do_post = MagicMock(return_value=[])
-    crawler = Crawler()
-    crawler.fetch(start="2020-11-20")
+@pytest.fixture
+def mock_client():
+    """Create a mock httpx client for testing"""
+    mock = MagicMock(spec=httpx.Client)
+    mock.get.return_value = MagicMock(status_code=200)
+    return mock
+
+
+class TestCrawlerUnit:
+    """Unit tests for Crawler that don't require network access"""
+
+    @patch('tefas.crawler._get_client')
+    def test_crawler_initialization(self, mock_get_client):
+        """Test that Crawler initializes correctly"""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_get_client.return_value = mock_client
+
+        crawler = Crawler()
+        assert crawler.client is mock_client
+        mock_client.get.assert_called_once_with(Crawler.root_url)
+        crawler.close()
+
+    @patch('tefas.crawler._get_client')
+    def test_crawler_context_manager(self, mock_get_client):
+        """Test the Crawler can be used as a context manager"""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_get_client.return_value = mock_client
+
+        with Crawler() as crawler:
+            assert crawler.client is mock_client
+
+        mock_client.close.assert_called_once()
+
+    @patch('tefas.crawler._get_client')
+    def test_crawler_close(self, mock_get_client):
+        """Test that close() closes the client"""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_get_client.return_value = mock_client
+
+        crawler = Crawler()
+        crawler.close()
+        mock_client.close.assert_called_once()
+
+    @patch('tefas.crawler._get_client')
+    def test_empty_result(self, mock_get_client):
+        """Test the client when POST to tefas returns empty list"""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        crawler = Crawler()
+        df = crawler.fetch(start="2020-11-20")
+        assert len(df) == 0
+        crawler.close()
+
+    @patch('tefas.crawler._get_client')
+    def test_invalid_kind_raises_error(self, mock_get_client):
+        """Test that invalid kind parameter raises ValueError"""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_get_client.return_value = mock_client
+
+        crawler = Crawler()
+        with pytest.raises(ValueError) as exc_info:
+            crawler.fetch(start="2020-11-20", kind="INVALID")
+        assert "`kind` should be one of" in str(exc_info.value)
+        crawler.close()
+
+
+class TestGetClient:
+    """Test the _get_client function"""
+
+    def test_get_client_returns_httpx_client(self):
+        """Test that _get_client returns an httpx Client"""
+        client = _get_client()
+        assert isinstance(client, httpx.Client)
+        client.close()
+
+    def test_get_client_has_timeout(self):
+        """Test that client has proper timeout configured"""
+        client = _get_client()
+        assert client.timeout.connect == 10.0
+        assert client.timeout.read == 30.0
+        client.close()
+
+    def test_get_client_follows_redirects(self):
+        """Test that client is configured to follow redirects"""
+        client = _get_client()
+        assert client.follow_redirects is True
+        client.close()
+
+
+class TestCrawlerIntegration:
+    """Integration tests that require network access - skipped by default"""
+
+    @pytest.mark.skip(reason="Requires network access to TEFAS servers")
+    def test_fetch_real_data(self):
+        """Test fetching real data from TEFAS"""
+        with Crawler() as crawler:
+            df = crawler.fetch(start="2020-11-20")
+            assert len(df) > 0
+            assert "code" in df.columns
+            assert "date" in df.columns
+            assert "price" in df.columns

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -1,12 +1,73 @@
 """Data schema validation"""
 
-from tefas import Crawler
 from tefas.schema import InfoSchema, BreakdownSchema
 
 
-def test_data_schema():
-    """Make an API call to Tefas and validate all required fields are present"""
-    crawler = Crawler()
-    df = crawler.fetch(start="2020-11-20")
-    all_fields = set(InfoSchema().fields).union(set(BreakdownSchema().fields))
-    assert all_fields == set(df.columns)
+class TestSchemaFields:
+    """Test that schemas have the expected fields"""
+
+    def test_info_schema_fields(self):
+        """Test InfoSchema has all required fields"""
+        schema = InfoSchema()
+        expected_fields = {
+            "date", "price", "code", "title",
+            "market_cap", "number_of_shares", "number_of_investors"
+        }
+        assert set(schema.fields.keys()) == expected_fields
+
+    def test_breakdown_schema_fields(self):
+        """Test BreakdownSchema has all portfolio breakdown fields"""
+        schema = BreakdownSchema()
+        # Check some key fields are present
+        assert "code" in schema.fields
+        assert "date" in schema.fields
+        assert "stock" in schema.fields
+        assert "government_bond" in schema.fields
+        assert "precious_metals" in schema.fields
+        assert "term_deposit" in schema.fields
+
+    def test_all_fields_union(self):
+        """Test that both schemas have code and date for merging"""
+        info_fields = set(InfoSchema().fields.keys())
+        breakdown_fields = set(BreakdownSchema().fields.keys())
+
+        # Both should have code and date for merging
+        assert "code" in info_fields
+        assert "date" in info_fields
+        assert "code" in breakdown_fields
+        assert "date" in breakdown_fields
+
+
+class TestSchemaDataTransforms:
+    """Test schema data transformation hooks"""
+
+    def test_info_schema_timestamp_conversion(self):
+        """Test that InfoSchema converts Unix timestamp to date"""
+        schema = InfoSchema()
+        # Unix timestamp in milliseconds (2020-11-20)
+        input_data = {
+            "TARIH": 1605830400000,  # 2020-11-20 00:00:00 UTC
+            "FIYAT": 41.302235,
+            "FONKODU": "AAK",
+            "FONUNVAN": "Test Fund",
+            "PORTFOYBUYUKLUK": 1000000.0,
+            "TEDPAYSAYISI": 1898223.0,
+            "KISISAYISI": 500.0
+        }
+        result = schema.load(input_data)
+        assert result["code"] == "AAK"
+        assert result["price"] == 41.302235
+        assert result["date"] is not None
+
+    def test_breakdown_schema_null_handling(self):
+        """Test that BreakdownSchema replaces None with 0.0 for float fields"""
+        schema = BreakdownSchema()
+        input_data = {
+            "TARIH": 1605830400000,
+            "FONKODU": "AAK",
+            "HS": None,  # stock field is None
+            "DT": 10.5,  # government_bond has value
+        }
+        result = schema.load(input_data)
+        assert result["stock"] == 0.0  # None should become 0.0
+        assert result["government_bond"] == 10.5


### PR DESCRIPTION
- Replace requests with httpx for modern SSL/TLS handling and better defaults
- Add tenacity for robust retry logic with exponential backoff
- Add python-dateutil for flexible date parsing (supports multiple formats)
- Replace print statements with proper logging module
- Add context manager support for Crawler class (with/as pattern)
- Update User-Agent to Chrome 131 (was Chrome 86)
- Use ssl.OP_LEGACY_SERVER_CONNECT constant instead of magic number 0x4
- Add comprehensive unit tests for date parsing and crawler functionality
- Improve test coverage with proper mocking (no network dependency)